### PR TITLE
argv -> argparse in combine_trios and kids_first

### DIFF
--- a/combine_trios.py
+++ b/combine_trios.py
@@ -2,18 +2,25 @@ import gzip
 import re
 import os
 import time
-from sys import argv
+import argparse
 import concurrent.futures
 
 startTime = time.time()
 char = '\n' + ('*' * 70) + '\n'
 
-#Input file or list of files
-inputFile = argv[1]
+#Input file
+parser = argparse.ArgumentParser(
+    description="Combine trio data into one VCF file"
+)
+parser.add_argument(
+    "inputFile",
+    help='A TSV with columns "file_name" and "family_id" listing the files to be combined'
+)
+args = parser.parse_args()
 
 #Create a dictionary of files that need to be combined into one vcf file
 fileDict = {}
-with open(inputFile) as sampleFile:
+with open(args.inputFile) as sampleFile:
     header = sampleFile.readline()
     headerList = header.rstrip().split("\t")
     fileNameIndex = headerList.index("file_name")
@@ -31,7 +38,7 @@ with open(inputFile) as sampleFile:
 
 probandDict = {}
 parentDict = {}
-with open(inputFile) as sampleFile:
+with open(args.inputFile) as sampleFile:
     header = sampleFile.readline()
     headerList = header.rstrip().split("\t")
     fileNameIndex = headerList.index("file_name")
@@ -69,7 +76,7 @@ def createFamFiles(proband):
             paternal = key
         else:
             maternal = key
-    with open(inputFile) as sampleFile:
+    with open(args.inputFile) as sampleFile:
         header = sampleFile.readline()
         headerList = header.rstrip().split("\t")
         fileNameIndex = headerList.index("file_name")

--- a/kids_first_meta.py
+++ b/kids_first_meta.py
@@ -2,22 +2,38 @@
 
 #Import necessary packages
 import time
-from sys import argv
+import argparse
 
 #Save time that script started
 startTime = time.time()
 
 #Input/output files
-manifestFile = argv[1]
-biospecimenFile = argv[2]
-clinicalFile = argv[3]
-outputFile = argv[4]
+parser = argparse.ArgumentParser(
+    description="Combine a manifest, biospecimen, and clinical file into an output TSV"
+)
+parser.add_argument(
+    "manifestFile", 
+    help='Path to a manifest TSV file with columns "File Name", "Family Id", "Aliquot External ID", and "Proband"'
+)
+parser.add_argument(
+    "biospecimenFile",
+    help='Path to a biospecimen TSV file with columns "External Aliquot Id" and "Biospecimens Id"'
+)
+parser.add_argument(
+    "clinicalFile",
+    help='Path to a clinical TSV file with columns "External Id" and "Gender"'
+)
+parser.add_argument(
+    "outputFile",
+    help='Path to the output file'
+)
+args = parser.parse_args()
 
 #Dictionary to store needed information in
 outputDict = {}
 
 #Obtain information from manifest file and add to initial dictionary
-with open(manifestFile) as manifest:
+with open(args.manifestFile) as manifest:
     manifestColumnNames = manifest.readline()
     manifestColumnNames = manifestColumnNames.rstrip().split("\t")
     #Information needed from this file are the "File Name", "Family Id", "Aliquot External ID", and "Proband" (Yes, or No).
@@ -34,7 +50,7 @@ with open(manifestFile) as manifest:
         outputDict[sample[manifestExternalIdIndex]] = [sample[fileNameIndex], sample[familyIdIndex], sample[probandIndex]]
 
 #Obtain information from the biospecimen file and add to initial dictionary
-with open(biospecimenFile) as biospecimen:
+with open(args.biospecimenFile) as biospecimen:
     biospecimenColumnNames = biospecimen.readline()
     biospecimenColumnNames = biospecimenColumnNames.rstrip().split("\t")
     #Information needed from this file are the "External Aliquot Id", and "Biospecimens Id"
@@ -47,7 +63,7 @@ with open(biospecimenFile) as biospecimen:
         outputDict[line[biospecimenExternalIdIndex]].append(line[sampleIdIndex])
 
 #Obtain gender information from the clinical file and add to initial dictionary
-with open(clinicalFile) as clinical:
+with open(args.clinicalFile) as clinical:
     clinicalColumnNames = clinical.readline()
     clinicalColumnNames = clinicalColumnNames.rstrip().split("\t")
     #Information needed from this file are the "External Id", and "Gender"
@@ -75,7 +91,7 @@ for key, value in familyDict.items():
         trioList.append(value[2])
 
 #Output information to outputFile
-with open(outputFile, 'w') as output:
+with open(args.outputFile, 'w') as output:
     output.write("file_name\tfamily_id\tsample_id\tproband\tsex\n")
     for item in trioList:
         if item[-1] == "Female":


### PR DESCRIPTION
Start migrating from argv to argparse.

Now, calling these two files from the command line will provide help text for command line arguments (try `python kids_first_meta.py -h`).